### PR TITLE
Implement segue/plumbing for Past Hike detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/HikeTracker/Base.lproj/Main.storyboard
+++ b/HikeTracker/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nFR-uY-ApT">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nFR-uY-ApT">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -81,11 +81,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="HikeCell" textLabel="rj0-dk-fMP" detailTextLabel="3vf-rx-ROh" style="IBUITableViewCellStyleSubtitle" id="Nb9-qA-D0A">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="HikeCell" textLabel="rj0-dk-fMP" detailTextLabel="3vf-rx-ROh" style="IBUITableViewCellStyleSubtitle" id="Nb9-qA-D0A">
                                 <rect key="frame" x="0.0" y="28" width="375" height="53.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Nb9-qA-D0A" id="qEB-Ad-bHq" customClass="TableViewCell" customModule="HikeTracker" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="53.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="348" height="53.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rj0-dk-fMP">
@@ -104,6 +104,9 @@
                                         </label>
                                     </subviews>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="SKV-eO-riH" kind="show" id="vbY-BJ-BeP"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <sections/>
@@ -115,7 +118,6 @@
                     <navigationItem key="navigationItem" title="Past Hikes" id="a3r-Sa-Yd6"/>
                     <connections>
                         <outlet property="hikeTableView" destination="Pbc-jd-CGg" id="HyN-Lc-vM6"/>
-                        <segue destination="SKV-eO-riH" kind="show" identifier="pastHikeStatSegue" id="Yh8-jr-p4M"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eeB-Fw-63o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -211,13 +213,23 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b8V-WE-gAC">
-                                <rect key="frame" x="31" y="63" width="313" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" name="Copperplate-Bold" family="Copperplate" pointSize="25"/>
-                                <color key="textColor" red="0.085059002829999994" green="0.63097520149999997" blue="0.098323041920000007" alpha="0.99978637699999995" colorSpace="custom" customColorSpace="sRGB"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="4MF-fE-qmr">
+                                <rect key="frame" x="20" y="64" width="335" height="44"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b8V-WE-gAC">
+                                        <rect key="frame" x="134" y="0.0" width="67" height="25.5"/>
+                                        <fontDescription key="fontDescription" name="Copperplate-Bold" family="Copperplate" pointSize="25"/>
+                                        <color key="textColor" red="0.085059002829999994" green="0.63097520149999997" blue="0.098323041920000007" alpha="0.99978637699999995" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IzP-85-xow">
+                                        <rect key="frame" x="147.5" y="26.5" width="40" height="17.5"/>
+                                        <fontDescription key="fontDescription" name="Copperplate" family="Copperplate" pointSize="17"/>
+                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" mapType="standard" showsCompass="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OD4-G2-Fml">
                                 <rect key="frame" x="27" y="306" width="317" height="282"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -234,15 +246,13 @@
                                 </items>
                                 <color key="barTintColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </toolbar>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IzP-85-xow">
-                                <rect key="frame" x="101" y="100" width="172" height="18"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" name="Copperplate" family="Copperplate" pointSize="17"/>
-                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="4MF-fE-qmr" firstAttribute="leading" secondItem="gid-lx-7xc" secondAttribute="leading" constant="20" id="GWX-db-Ya2"/>
+                            <constraint firstItem="gid-lx-7xc" firstAttribute="trailing" secondItem="4MF-fE-qmr" secondAttribute="trailing" constant="20" id="t1M-e1-0F4"/>
+                            <constraint firstItem="4MF-fE-qmr" firstAttribute="top" secondItem="gid-lx-7xc" secondAttribute="top" constant="20" id="zTD-CO-xCZ"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="gid-lx-7xc"/>
                     </view>
                     <navigationItem key="navigationItem" title="Past Hike" id="Wgs-sI-qq7"/>

--- a/HikeTracker/View Controllers/PastHikeDetailViewController.swift
+++ b/HikeTracker/View Controllers/PastHikeDetailViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import MapKit
+import CoreData
 
 class PastHikeDetailViewController: UIViewController {
     
@@ -15,23 +16,34 @@ class PastHikeDetailViewController: UIViewController {
     @IBOutlet weak var hikeDate: UILabel!
     @IBOutlet weak var totalTime: UILabel!
     @IBOutlet weak var totalDistance: UILabel!
-    @IBOutlet weak var averagePace: UILabel!
+    @IBOutlet weak var averagePace: UILabel! 
     @IBOutlet weak var totalAltitudeGained: UILabel!
     @IBOutlet weak var totalAltitudeLost: UILabel!
     @IBOutlet weak var mapView: MKMapView!
     @IBOutlet weak var deleteHikeButton: UIToolbar!
     
-    var selectedRow = 0
-//    let selectedHikeArray = [NSArray] = []
-    var pastHikeTitle = ""
-    var pastHikeDate = ""
-    var pastHikeDuration = 0
-    var pastHikeDistance = 0.0
-    var pastHikeAltGain = 0
-    var pastHikeAltLoss = 0
-    var pastHikeCoordinates: [CLLocation] = []
+    let dateFormatter = DateFormatter()
+    
+    var hike: NSManagedObject?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        dateFormatter.dateFormat = "EEEE, MMM d, yyyy"
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        if let hike = hike {
+            hikeTitle.text = "\(hike.value(forKey: "name") as! String)"
+            hikeDate.text = dateFormatter.string(from: hike.value(forKey: "timestamp") as! Date)
+            totalTime.text = "\(hike.value(forKey: "duration") as! Int)"
+            totalDistance.text = "\(hike.value(forKey: "distance") as! Double)"
+            averagePace.text = ""  // TODO: math
+            totalAltitudeGained.text = "\(hike.value(forKey: "elevation_gain") as! Int)"
+            totalAltitudeLost.text = "\(hike.value(forKey: "elevation_loss") as! Int)"
+            // TODO: configure vc.mapView
+        }
     }
 }

--- a/HikeTracker/View Controllers/PastHikeDetailViewController.swift
+++ b/HikeTracker/View Controllers/PastHikeDetailViewController.swift
@@ -24,7 +24,7 @@ class PastHikeDetailViewController: UIViewController {
     
     let dateFormatter = DateFormatter()
     
-    var hike: NSManagedObject?
+    weak var hike: NSManagedObject?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/HikeTracker/View Controllers/PastHikesController.swift
+++ b/HikeTracker/View Controllers/PastHikesController.swift
@@ -14,8 +14,7 @@ class PastHikesViewController: UIViewController {
     @IBOutlet weak var hikeTableView: UITableView!
     
     var hikeArray = [NSManagedObject]()
-    var selectedRowIndex = 0
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -37,11 +36,17 @@ class PastHikesViewController: UIViewController {
         } catch {
             print("Failed")
         }
+        
+        // Clear last selection
+        if let indexPath = hikeTableView.indexPathForSelectedRow {
+            hikeTableView.deselectRow(at: indexPath, animated: true)
+        }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let vc = segue.destination as! PastHikeDetailViewController
-        let hike = hikeArray[selectedRowIndex]
+        let indexPath = hikeTableView.indexPathForSelectedRow!
+        let hike = hikeArray[indexPath.row]
         vc.hike = hike
     }
 }
@@ -61,11 +66,6 @@ extension PastHikesViewController: UITableViewDataSource, UITableViewDelegate {
         cell.textLabel?.text = "\(hike.value(forKey: "name") ?? "Error")"
         cell.detailTextLabel?.text = "\(dateFormatter.string(from: hikeDate as! Date))"
         return cell
-    }
-    
-    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        selectedRowIndex = indexPath.row
-        return indexPath
     }
 }
 

--- a/HikeTracker/View Controllers/PastHikesController.swift
+++ b/HikeTracker/View Controllers/PastHikesController.swift
@@ -38,6 +38,12 @@ class PastHikesViewController: UIViewController {
             print("Failed")
         }
     }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        let vc = segue.destination as! PastHikeDetailViewController
+        let hike = hikeArray[selectedRowIndex]
+        vc.hike = hike
+    }
 }
 
 
@@ -55,6 +61,11 @@ extension PastHikesViewController: UITableViewDataSource, UITableViewDelegate {
         cell.textLabel?.text = "\(hike.value(forKey: "name") ?? "Error")"
         cell.detailTextLabel?.text = "\(dateFormatter.string(from: hikeDate as! Date))"
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        selectedRowIndex = indexPath.row
+        return indexPath
     }
 }
 


### PR DESCRIPTION
Changes:
- PastHike table view passes Hike object to detail view controller on selection. 
- Detail view controller now configures its UI own elements, on appearance, using a weak reference to the selected hike object. 

To do:
- Finish setting up map view
- Do some division for "average pace" label
- Add measurement units to time/distance/altitude labels